### PR TITLE
Update contrastive_loss_layer.cu

### DIFF
--- a/src/caffe/layers/contrastive_loss_layer.cu
+++ b/src/caffe/layers/contrastive_loss_layer.cu
@@ -66,7 +66,7 @@ __global__ void CLLBackward(const int count, const int channels,
       Dtype beta(0.0);
       if (legacy_version) {
         mdist = (margin - dist_sq[n]);
-        beta = -alpha;
+        beta = -alpha * diff[i];
       } else {
         Dtype dist = sqrt(dist_sq[n]);
         mdist = (margin - dist);


### PR DESCRIPTION
fix a bug in the back propagation procedure ( when legacy_version==true ).
